### PR TITLE
front-end forgot my password feature and handling

### DIFF
--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -94,6 +94,8 @@ export const handlePwResetAndLogin = user => (store) => {
 
 export const handleForgotMyPassword = user => (store) => {
   console.log(user);
+  const encodedAnswer = Buffer.from(user.recoveryAnswer).toString('base64');
+  user.recoveryAnswer = encodedAnswer;
   return superagent.post(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
     .send(user)
     .then((recieved) => {

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -92,6 +92,10 @@ export const handlePwResetAndLogin = user => (store) => {
     });
 };
 
+export const handleForgotMyPassword = user => (store) => {
+  console.log(user);
+};
+
 // handle using token post refresh
 function findMeTheToken(strToFind) {
   const cookies = document.cookie.split(';');

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -106,6 +106,7 @@ export const handleForgotMyPassword = user => (store) => {
       // handleForgotMyPassword() for rendering on screen for user
       console.log('handleForgotMyPassword super-agent GET return:');
       console.log(dataRecieved);
+      return dataRecieved.temporaryPassword;
     })
     .catch((error) => {
       return new Error(error);

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -94,7 +94,7 @@ export const handlePwResetAndLogin = user => (store) => {
 
 export const handleForgotMyPassword = user => (store) => {
   console.log(user);
-  return superagent.get(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
+  return superagent.post(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
     .send(user)
     .then((recieved) => {
       const dataRecieved = JSON.parse(recieved.text);

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -94,6 +94,15 @@ export const handlePwResetAndLogin = user => (store) => {
 
 export const handleForgotMyPassword = user => (store) => {
   console.log(user);
+  return superagent.get(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
+    .send(user)
+    .then((recieved) => {
+      console.log('handleForgotMyPassword super-agent GET return:');
+      console.log(recieved);
+    })
+    .catch((error) => {
+      return new Error(error);
+    });
 };
 
 // handle using token post refresh

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -94,12 +94,16 @@ export const handlePwResetAndLogin = user => (store) => {
 
 export const handleForgotMyPassword = user => (store) => {
   console.log(user);
-  const encodedAnswer = Buffer.from(user.recoveryAnswer).toString('base64');
-  user.recoveryAnswer = encodedAnswer;
+  // encode recoveryAnswer for sending as request obj
+  user.recoveryAnswer = Buffer.from(user.recoveryAnswer).toString('base64');
   return superagent.post(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
     .send(user)
     .then((recieved) => {
       const dataRecieved = JSON.parse(recieved.text);
+      // receive new temp pw from back-end and decode
+      dataRecieved.temporaryPassword = Buffer.from(dataRecieved.temporaryPassword, 'base64').toString();
+      // Data now being properly received, and needs to be returned to landing method
+      // handleForgotMyPassword() for rendering on screen for user
       console.log('handleForgotMyPassword super-agent GET return:');
       console.log(dataRecieved);
     })

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -104,12 +104,10 @@ export const handleForgotMyPassword = user => (store) => {
       dataRecieved.temporaryPassword = Buffer.from(dataRecieved.temporaryPassword, 'base64').toString();
       // Data now being properly received, and needs to be returned to landing method
       // handleForgotMyPassword() for rendering on screen for user
-      console.log('handleForgotMyPassword super-agent GET return:');
-      console.log(dataRecieved);
       return dataRecieved.temporaryPassword;
     })
     .catch((error) => {
-      return new Error(error);
+      return error.response;
     });
 };
 

--- a/src/action/auth.js
+++ b/src/action/auth.js
@@ -97,8 +97,9 @@ export const handleForgotMyPassword = user => (store) => {
   return superagent.get(`${API_URL}${routes.FORGOT_PW_BACKEND}`)
     .send(user)
     .then((recieved) => {
+      const dataRecieved = JSON.parse(recieved.text);
       console.log('handleForgotMyPassword super-agent GET return:');
-      console.log(recieved);
+      console.log(dataRecieved);
     })
     .catch((error) => {
       return new Error(error);

--- a/src/components/landing/landing.js
+++ b/src/components/landing/landing.js
@@ -52,23 +52,29 @@ class Landing extends React.Component {
     return this.props.handleForgotMyPassword(user);
   };
 
+  returnDefaultLogo = () => {
+    return <Link to='/'>
+      <img src={defaultLogo} className='logo'/>
+    </Link>;
+  };
+
   render() {
     const rootJSX = <div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <Link to='/signup' className='centered button'>Create an account</Link>
       <br/>
       <Link to='/login' className='centered button'>Login</Link>
     </div>;
 
     const signUpJSX = <div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <AuthForm type='signup' onComplete={this.handleSignup}/>
       <span className='base'>Already have an account?</span>
       <Link className="spacing" to='/login'>Login to RIMS</Link>
     </div>;
 
     const loginJSX = <div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <AuthForm type='login' onComplete={this.handleLogin}/>
       <span className='base'>Help me with something else?</span>
       <Link className="spacing" to='/signup'>Create an account</Link>
@@ -76,7 +82,7 @@ class Landing extends React.Component {
     </div>;
 
     const resetPwJSX = <div div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <ResetPwForm type="reset" onComplete={this.handlePwResetAndLogin}/>
       <span className='base'>Help me with something else?</span>
       <Link className="spacing" to='/login'>Login to RIMS</Link>
@@ -84,16 +90,17 @@ class Landing extends React.Component {
     </div>;
 
     const forgotPwJSX = <div div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <ResetPwForm type="forgot" onComplete={this.handleForgotMyPassword}/>
       <span className='base'>Help me with something else?</span>
+      <Link className="spacing" to='/login'>Login to RIMS</Link>
       <Link className="spacing" to='/signup'>Signup for RIMS</Link>
       <Link className="spacing" to='/forgot-un'>Forgot Username</Link>
       <Link className="spacing" to='/reset-pw'>Reset password</Link>
     </div>;
 
     const forgotUnJSX = <div div className='centered'>
-      <img src={defaultLogo} className='logo'/>
+      {this.returnDefaultLogo()}
       <p style={ {'text-align': 'center'} }>
         Send username to email is currently not supported. Come back soon.
       </p>

--- a/src/components/landing/landing.js
+++ b/src/components/landing/landing.js
@@ -47,6 +47,11 @@ class Landing extends React.Component {
       });
   };
 
+  handleForgotMyPassword = (user) => {
+    console.log('action: handleForgotMyPassword()');
+    return this.props.handleForgotMyPassword(user);
+  };
+
   render() {
     const rootJSX = <div className='centered'>
       <img src={defaultLogo} className='logo'/>
@@ -80,7 +85,7 @@ class Landing extends React.Component {
 
     const forgotPwJSX = <div div className='centered'>
       <img src={defaultLogo} className='logo'/>
-      <ResetPwForm type="forgot"/>
+      <ResetPwForm type="forgot" onComplete={this.handleForgotMyPassword}/>
       <span className='base'>Help me with something else?</span>
       <Link className="spacing" to='/signup'>Signup for RIMS</Link>
       <Link className="spacing" to='/forgot-un'>Forgot Username</Link>
@@ -127,6 +132,7 @@ const mapDispatchToProps = dispatch => ({
   pGetUsers: users => dispatch(dataActions.getUsers(users)),
   pGetSubAssy: subAssy => dispatch(dataActions.getSubAssy(subAssy)),
   pGetParts: parts => dispatch(dataActions.getParts(parts)),
+  handleForgotMyPassword: user => dispatch(authActions.handleForgotMyPassword(user)),
 });
 
 Landing.propTypes = {
@@ -137,6 +143,7 @@ Landing.propTypes = {
   pGetSubAssy: PropTypes.func,
   pGetParts: PropTypes.func,
   handlePwResetAndLogin: PropTypes.func,
+  handleForgotMyPassword: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Landing);

--- a/src/components/landing/landing.js
+++ b/src/components/landing/landing.js
@@ -17,6 +17,7 @@ class Landing extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+    this.state.tempPw = false;
     // setup store with needed DB data
     this.props.pGetUsers();
   }
@@ -49,7 +50,21 @@ class Landing extends React.Component {
 
   handleForgotMyPassword = (user) => {
     console.log('action: handleForgotMyPassword()');
-    return this.props.handleForgotMyPassword(user);
+    return this.props.handleForgotMyPassword(user)
+    // if successful, action should return with temporary password to display for user
+      .then((tempPw) => {
+        const testComponent = <section className="tempPwDiv">
+          <p><span className="tempPwText">NOTE:</span></p>
+          <p>Save the below <span className="tempPw">pw</span> immediately.</p>
+          <p>You will be locked from your account if you do not retain it before the page refreshes.</p>
+          <p>We recommend heading to the reset-pw page and using this temporary pw immediately reset your account pw.</p>
+          <p className="tempPw">{tempPw}</p>
+        </section>;
+        this.setState({tempPw: testComponent});
+      })
+      .catch((error) => {
+        return error;
+      });
   };
 
   returnDefaultLogo = () => {
@@ -91,7 +106,11 @@ class Landing extends React.Component {
 
     const forgotPwJSX = <div div className='centered'>
       {this.returnDefaultLogo()}
-      <ResetPwForm type="forgot" onComplete={this.handleForgotMyPassword}/>
+      {this.state.tempPw ? this.state.tempPw : null}
+      {
+        !this.state.tempPw ?  <ResetPwForm type="forgot" onComplete={this.handleForgotMyPassword}/>
+        : null
+      }
       <span className='base'>Help me with something else?</span>
       <Link className="spacing" to='/login'>Login to RIMS</Link>
       <Link className="spacing" to='/signup'>Signup for RIMS</Link>

--- a/src/components/landing/landing.scss
+++ b/src/components/landing/landing.scss
@@ -26,3 +26,16 @@ Link a {
 p {
   color: $color-primary;
 }
+
+.tempPwDiv {
+  text-align: center;
+  font-size: 15px;
+}
+
+.tempPw {
+  color: red;
+}
+
+.tempPwText {
+  font-weight: bold;
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -11,6 +11,7 @@ export const POST_SUBASSY_BACKEND = '/subassemblies';
 export const POST_LOGO_BACKEND = '/company-logo/upload';
 export const GET_LOGO_BACKEND = '/company-logo';
 export const GET_PW_RESET_BACKEND = '/reset-pw';
+export const FORGOT_PW_BACKEND = '/forgot-pw';
 
 // front-end routes
 export const SITE_ROOT_FRONTEND = '/';

--- a/style/base.scss
+++ b/style/base.scss
@@ -56,6 +56,7 @@ html {
 
 .logo:hover {
   outline: none;
+  cursor: pointer;
   border: .5px solid rgba(255,171,64, 0.2);
   // box-shadow: 0 0 20px #9ecaed;
   box-shadow: 0px 0px 4000px 1px $buttonHoverBackground;


### PR DESCRIPTION
associated back-end PR:
https://github.com/bgwest/RIMS-back-end/pull/7

Not a ton of code in either PR here, but there was a lot to think about on this one. Took a lot of time just slowly adding handling to front and back-end and inching towards the goal. I didn't think it was wise to send the answer without doing at minimum a base64 encoding on it. So that is being done on initial sends and returns. Bcrypt is still handling the full hashing on schema store.

One thing that needs to be updated is the original account signup sending. Initial PW is auto being base64 encoded by superagent, but I believe our recoveryAnswer is being send to back-end in plain text but then we hash it in the DB. I left a comment on the back-end PR in one of the files to note to return to that.

Please let me know if you have any questions. Please also review/merge/test when you have time. Thanks, Tom!

Ben